### PR TITLE
1 line code to support Chinese caption

### DIFF
--- a/web_demo_captioner.py
+++ b/web_demo_captioner.py
@@ -57,6 +57,9 @@ def _launch_demo(args, model, processor):
 
         if use_transformers:
             text = processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+            # use a prefix, such as a Chinese prompt, to support Chinese output
+            # text = processor. apply_chat_template(messages, add_generation_prompt=False, tokenize=False)
+            # text = text + "<|im_start|>assistant\n这个音频剪辑"
 
             audios, _, _ = process_mm_info(messages, use_audio_in_video=True)
 


### PR DESCRIPTION
By default, it only outputs English captions and does not support instruction inputs. 
Fortunately, some instructions may be implemented using prefixes.